### PR TITLE
Option to reject users not in DB

### DIFF
--- a/src/config/shibboleth.php
+++ b/src/config/shibboleth.php
@@ -2,7 +2,7 @@
 
 return array(
 
-	'package' => 'saitswebuwm/shibboleth',
+	'package'                => 'saitswebuwm/shibboleth',
 
 	/*
 	|--------------------------------------------------------------------------
@@ -15,13 +15,13 @@ return array(
 	|
 	| Supported: "database", "eloquent"
 	|
-	*/
+	 */
 
-    'port' => ':443',
-    'idp_login' => '/Shibboleth.sso/Login',
-    'idp_logout' => '/Shibboleth.sso/Logout',
-    'local_logout' => 'shibboleth::local',
-    'login_fail' => 'shibboleth::unauthorized',
+	'port'                   => ':443',
+	'idp_login'              => '/Shibboleth.sso/Login',
+	'idp_logout'             => '/Shibboleth.sso/Logout',
+	'local_logout'           => 'shibboleth::local',
+	'login_fail'             => 'shibboleth::unauthorized',
 
 	/*
 	|--------------------------------------------------------------------------
@@ -31,35 +31,35 @@ return array(
 	| Allows you to emulate an IdP without setting up a test Shibboleth env.
 	| Do NOT use this in production for any reason whatsoever.
 	| You have been warned.
-	| 
+	|
 	| YOU MUST USE FALSE AND NOT "FALSE" PHP CONVERTS ALL STRINGS EXCEPT "0" TO TRUE.
 	|
-	*/
-	'emulate_idp' => false,
-	'emulate_idp_users' => array(
+	 */
+	'emulate_idp'            => false,
+	'emulate_idp_users'      => array(
 		'admin' => array(
-			'uid' => 'admin',
+			'uid'         => 'admin',
 			'displayName' => 'Admin User',
-			'givenName' => 'Admin',
-			'sn' => 'User',
-			'mail' => 'admin@uwm.edu',
+			'givenName'   => 'Admin',
+			'sn'          => 'User',
+			'mail'        => 'admin@uwm.edu',
 		),
 		'staff' => array(
-			'uid' => 'staff',
+			'uid'         => 'staff',
 			'displayName' => 'Staff User',
-			'givenName' => 'Staff',
-			'sn' => 'User',
-			'mail' => 'staff@uwm.edu',
+			'givenName'   => 'Staff',
+			'sn'          => 'User',
+			'mail'        => 'staff@uwm.edu',
 		),
-		'user' => array(
-			'uid' => 'user',
+		'user'  => array(
+			'uid'         => 'user',
 			'displayName' => 'User User',
-			'givenName' => 'User',
-			'sn' => 'User',
-			'mail' => 'user@uwm.edu',
+			'givenName'   => 'User',
+			'sn'          => 'User',
+			'mail'        => 'user@uwm.edu',
 		),
 	),
-	
+
 	/*
 	|--------------------------------------------------------------------------
 	| Default Views
@@ -68,37 +68,38 @@ return array(
 	| Default views, to change to the views you made you can change the following
 	| lines.
 	|
-	*/
+	 */
 
-    'login_view' => 'shibboleth::local', // View that local users should use to login
-    'shibboleth_view' => 'shibboleth::authorized', // View shibboleth users see after authenticating
-    'default_view' => 'shibboleth::authorized', // View users see after authenticating
-    'default_unauth' => 'shibboleth::unauthorized', // View users see when rejected
+	'login_view'             => 'shibboleth::local', // View that local users should use to login
+	'shibboleth_view'        => 'shibboleth::authorized', // View shibboleth users see after authenticating
+	'default_view'           => 'shibboleth::authorized', // View users see after authenticating
+	'default_unauth'         => 'shibboleth::unauthorized', // View users see when rejected
 
 	/*
 	|--------------------------------------------------------------------------
-	| Defaults Settings 
+	| Defaults Settings
 	|--------------------------------------------------------------------------
 	|
 	| Change these setting do the proper values for your idp.
 	|
-	*/
+	 */
 
 	'local_login_user_field' => 'local_email', //post field used to get username
 	'local_login_pass_field' => 'local_password', //post field used to get password
-	'idp_login_email' => 'mail', //idp server variable for email address
-	'idp_login_first' => 'givenName', //idp server variable for first name
-	'idp_login_last' => 'sn', //idp server variable for last name
+	'idp_login_email'        => 'mail', //idp server variable for email address
+	'idp_login_first'        => 'givenName', //idp server variable for first name
+	'idp_login_last'         => 'sn', //idp server variable for last name
 
 	/*
 	|--------------------------------------------------------------------------
-	| Groups Settings
+	| User Creation and Groups Settings
 	|--------------------------------------------------------------------------
 	|
-	| Change the group setting according to your database and program requirements.
+	| Allows you to change if/how new users are added
 	|
-	*/
+	 */
 
-	'shibboleth_group' => '1', // Default group ID shibboleth users will be added to
+	'add_new_users'          => true, // Whether new shibboleth users should be added
+	'shibboleth_group'       => '1', // Default group ID shibboleth users will be added to
 
 );

--- a/src/controllers/ShibbolethController.php
+++ b/src/controllers/ShibbolethController.php
@@ -1,228 +1,231 @@
 <?php namespace Saitswebuwm\Shibboleth;
 
-use Illuminate\Support\Facades\Redirect;
-use Illuminate\Support\Facades\Session;
-use Illuminate\Support\Facades\Request;
-use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\View;
 use Illuminate\Auth\GenericUser;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Facades\Session;
+use Illuminate\Support\Facades\View;
 
 class ShibbolethController extends Controller {
 
-    //Config pathings
-    private $cpath = "shibboleth::shibboleth";
-    private $ctrpath = "Saitswebuwm\\Shibboleth\\ShibbolethController@";
-    
+	//Config pathings
+	private $cpath   = "shibboleth::shibboleth";
+	private $ctrpath = "Saitswebuwm\\Shibboleth\\ShibbolethController@";
+
 	private $sp;
 	private $idp;
 	private $config;
-	
-    /**
-     * Inject the user into this controller if present.
-     */
-    public function __construct(GenericUser $user = null)
-    {
-		if (Config::get("$this->cpath.emulate_idp") == true)
-		{
-			$this->config = new \Shibalike\Config();
+
+	/**
+	 * Inject the user into this controller if present.
+	 */
+	public function __construct(GenericUser $user = null) {
+		if (Config::get("$this->cpath.emulate_idp") == true) {
+			$this->config         = new \Shibalike\Config();
 			$this->config->idpUrl = 'idp';
-			
+
 			$stateManager = $this->getStateManager();
 
 			$this->sp = new \Shibalike\SP($stateManager, $this->config);
 			$this->sp->initLazySession();
-			
+
 			$this->idp = new \Shibalike\IdP($stateManager, $this->getAttrStore(), $this->config);
 		}
-		
+
 		$this->user = $user;
-    }
-    
-    /**
-     * Create the session, send the user away to the IDP
-     * for authentication.
-     */
-    public function create()
-    {
-		if (Config::get("$this->cpath.emulate_idp") == true)
-		{
-			return Redirect::to( action($this->ctrpath . 'emulateLogin') . '?target=' . action($this->ctrpath . "idpAuthorize"));
+	}
+
+	/**
+	 * Create the session, send the user away to the IDP
+	 * for authentication.
+	 */
+	public function create() {
+		if (Config::get("$this->cpath.emulate_idp") == true) {
+			return Redirect::to(action($this->ctrpath . 'emulateLogin') . '?target=' . action($this->ctrpath . "idpAuthorize"));
+		} else {
+			return Redirect::to('https://' . Request::server('SERVER_NAME') . ':' . Request::server('SERVER_PORT') . Config::get("$this->cpath.idp_login") . '?target=' . action($this->ctrpath . "idpAuthorize"));
 		}
-		else
-		{
-			return Redirect::to( 'https://' . Request::server('SERVER_NAME') . ':' . Request::server('SERVER_PORT') . Config::get("$this->cpath.idp_login") . '?target=' . action($this->ctrpath . "idpAuthorize"));
-		}
-    }
-    
-    /**
-     * Login for users not using the IDP
-     */
-    public function localCreate()
-    {
-        return View::make(Config::get("$this->cpath.login_view"));
-    }
-    
+	}
+
+	/**
+	 * Login for users not using the IDP
+	 */
+	public function localCreate() {
+		return View::make(Config::get("$this->cpath.login_view"));
+	}
+
 	/**
 	 * Authorize function for users not using the IdP
 	 */
-    public function localAuthorize()
-    {
-        $email = \Input::get(Config::get("$this->cpath.local_login_user_field"));
-        $password = \Input::get(Config::get("$this->cpath.local_login_pass_field"));
+	public function localAuthorize() {
+		$email    = \Input::get(Config::get("$this->cpath.local_login_user_field"));
+		$password = \Input::get(Config::get("$this->cpath.local_login_pass_field"));
 
-        if (Auth::attempt(array('email' => $email, 'password' => $password), true))
-        {
-            $user = UserShibboleth::where('email', '=', $email)->first();
-            if (isset($user->first_name)) Session::put('first', $user->first_name);
-            if (isset($user->last_name)) Session::put('last', $user->last_name);
-            if (isset($email)) Session::put('email', $user->email);
-            if (isset($email)) Session::put('id', UserShibboleth::where('email', '=', $email)->first()->id); //TODO: Look at this
+		if (Auth::attempt(array('email' => $email, 'password' => $password), true)) {
+			$user = UserShibboleth::where('email', '=', $email)->first();
+			if (isset($user->first_name)) {
+				Session::put('first', $user->first_name);
+			}
 
+			if (isset($user->last_name)) {
+				Session::put('last', $user->last_name);
+			}
 
-            //Group Session Field
-            if (isset($email)){
-                try{
-                    $group = Group::whereHas('users', function($q){
-                        $q->where('email', '=', Request::server(Config::get("$this->cpath.idp_login_email")));
-                    })->first();
+			if (isset($email)) {
+				Session::put('email', $user->email);
+			}
 
-                    Session::put('group', $group->name);
-                }catch(Exception $e){ // TODO: Remove later after all auth is set up.
-                    Session::put('group', 'undefined');
-                }
-            }
+			if (isset($email)) {
+				Session::put('id', UserShibboleth::where('email', '=', $email)->first()->id);
+			}
+			//TODO: Look at this
 
-            //Set session to know user is local
-            Session::put('auth_type', 'local');
-            return View::make('/local_landing');
-        }
-        else
-        {
-            return View::make(Config::get("$this->cpath.login_fail"));
-        }
-    }
-    
+			//Group Session Field
+			if (isset($email)) {
+				try {
+					$group = Group::whereHas('users', function ($q) {
+						$q->where('email', '=', Request::server(Config::get("$this->cpath.idp_login_email")));
+					})->first();
+
+					Session::put('group', $group->name);
+				} catch (Exception $e) {
+					// TODO: Remove later after all auth is set up.
+					Session::put('group', 'undefined');
+				}
+			}
+
+			//Set session to know user is local
+			Session::put('auth_type', 'local');
+			return View::make('/local_landing');
+		} else {
+			return View::make(Config::get("$this->cpath.login_fail"));
+		}
+	}
+
 	/**
 	 * Local user landing page
 	 */
-    public function local_landing()
-    {
-        return View::make(Config::get("$this->cpath.default_view"));
-    }
+	public function local_landing() {
+		return View::make(Config::get("$this->cpath.default_view"));
+	}
 
-    /**
-     * Setup authorization based on returned server variables
-     * from the IdP.
-     */
-    public function idpAuthorize()
-    {
-        $email = $this->getServerVariable(Config::get("$this->cpath.idp_login_email"));
-        $first_name = $this->getServerVariable(Config::get("$this->cpath.idp_login_first"));
-        $last_name = $this->getServerVariable(Config::get("$this->cpath.idp_login_last"));
-		
-        // Attempt to login with the email, if success, update the user model
-        // with data from the Shibboleth headers (if present)
-        if (Auth::attempt(array('email' => $email), true))
-        {
-            if (isset($first_name)) Session::put('first', $first_name);
-            if (isset($last_name)) Session::put('last', $last_name);
-            if (isset($email)) Session::put('email', $email);
-            if (isset($email)) Session::put('id', UserShibboleth::where('email', '=', $email)->first()->id); //TODO: Check this
+	/**
+	 * Setup authorization based on returned server variables
+	 * from the IdP.
+	 */
+	public function idpAuthorize() {
+		$email      = $this->getServerVariable(Config::get("$this->cpath.idp_login_email"));
+		$first_name = $this->getServerVariable(Config::get("$this->cpath.idp_login_first"));
+		$last_name  = $this->getServerVariable(Config::get("$this->cpath.idp_login_last"));
 
-            //Group Session Field
-            if (isset($email))
-			{
-                try
-                {
-                    $group = Group::whereHas('users', function($q){
-                        $q->where('email', '=', $this->getServerVariable(Config::get("$this->cpath.idp_login_email")));
-                    })->first();
-
-                    Session::put('group', $group->name);
-                }
-                catch(Exception $e)
-                { // TODO: Remove later after all auth is set up.
-                    Session::put('group', 'undefined');
-                }
-            }
-
-
-            //Set session to know user is idp
-            Session::put('auth_type', 'idp');
-            
-            $shib_view_config = Config::get("$this->cpath.shibboleth_view");
-            //Check if route exists else redirect
-            if (View::exists($shib_view_config)) return View::make($shib_view_config);
-            else return Redirect::to($shib_view_config);
-        }
-        else
-        {
-            //Add user to group and send through auth.
-            if (isset($email))
-			{
-                $user = UserShibboleth::create(array(
-                        'email' => $email,
-                        'type' => 'shibboleth',
-                        'first_name' => $first_name,
-                        'last_name' => $last_name,
-                        'enabled' => 0
-                    ));
-                $group = Group::find(Config::get("$this->cpath.shibboleth_group"));
-
-                $group->users()->save($user);
-
-                return Redirect::to('https://' . Request::server('SERVER_NAME') . ':' . Request::server('SERVER_PORT') . Config::get("$this->cpath.idp_login") . '?target=' . action($this->ctrpath . "idpAuthorize"));
-            }
-
-            return View::make(Config::get("$this->cpath.login_fail"));
-        }
-    }
-
-    public function idp_landing()
-    {
-        return View::make(Config::get("$this->cpath.shibboleth_view"));
-    }
-    
-    /**
-     * Get current information about the session.
-     */
-    public function session()
-    {
-        echo 'Logged In: ' . ((Auth::check()) ? 'yes' : 'no') . '<br />';
-        echo 'Session Information: <br />' . var_dump(Session::all());
-    }
-    
-    /**
-     * Destroy the current session and log the user out, redirect them to the main route.
-     */
-    public function destroy()
-    {
-        Auth::logout();
-
-        if(Session::get('auth_type') == 'idp')
-		{
-			if (Config::get("$this->cpath.emulate_idp") == true)
-			{ 
-				Session::flush();
-				return Redirect::to( action($this->ctrpath . 'emulateLogout'));
+		// Attempt to login with the email, if success, update the user model
+		// with data from the Shibboleth headers (if present)
+		if (Auth::attempt(array('email' => $email), true)) {
+			if (isset($first_name)) {
+				Session::put('first', $first_name);
 			}
-			else
-			{
+
+			if (isset($last_name)) {
+				Session::put('last', $last_name);
+			}
+
+			if (isset($email)) {
+				Session::put('email', $email);
+			}
+
+			if (isset($email)) {
+				Session::put('id', UserShibboleth::where('email', '=', $email)->first()->id);
+			}
+			//TODO: Check this
+
+			//Group Session Field
+			if (isset($email)) {
+				try
+				{
+					$group = Group::whereHas('users', function ($q) {
+						$q->where('email', '=', $this->getServerVariable(Config::get("$this->cpath.idp_login_email")));
+					})->first();
+
+					Session::put('group', $group->name);
+				} catch (Exception $e) {
+					// TODO: Remove later after all auth is set up.
+					Session::put('group', 'undefined');
+				}
+			}
+
+			//Set session to know user is idp
+			Session::put('auth_type', 'idp');
+
+			//Check if route exists else redirect
+			return $this->viewOrRedirect(Config::get("$this->cpath.shibboleth_view"));
+
+		} else {
+			//Add user to group and send through auth.
+			if (isset($email)) {
+				if (Config::get("$this->cpath.add_new_users")) {
+					$user = UserShibboleth::create(array(
+						'email'      => $email,
+						'type'       => 'shibboleth',
+						'first_name' => $first_name,
+						'last_name'  => $last_name,
+						'enabled'    => 0,
+					));
+					$group = Group::find(Config::get("$this->cpath.shibboleth_group"));
+
+					$group->users()->save($user);
+
+					// this is simply brings us back to the session-setting branch directly above
+					// TODO: refactor and split the purposes of these functions better
+					return Redirect::to('https://' . Request::server('SERVER_NAME') . ':' . Request::server('SERVER_PORT') . Config::get("$this->cpath.idp_login") . '?target=' . action($this->ctrpath . "idpAuthorize"));
+				} else {
+					//Identify that the user was not in our database and will not be created (despite passing IdP)
+					Session::put('auth_type', 'no_user');
+					Session::put('group', 'undefined');
+
+					return $this->viewOrRedirect(Config::get("$this->cpath.login_fail"));
+				}
+			}
+
+			return View::make(Config::get("$this->cpath.login_fail"));
+		}
+	}
+
+	public function idp_landing() {
+		return View::make(Config::get("$this->cpath.shibboleth_view"));
+	}
+
+	/**
+	 * Get current information about the session.
+	 */
+	public function session() {
+		echo 'Logged In: ' . ((Auth::check()) ? 'yes' : 'no') . '<br />';
+		echo 'Session Information: <br />' . var_dump(Session::all());
+	}
+
+	/**
+	 * Destroy the current session and log the user out, redirect them to the main route.
+	 */
+	public function destroy() {
+		Auth::logout();
+
+		if (Session::get('auth_type') == 'idp') {
+			if (Config::get("$this->cpath.emulate_idp") == true) {
 				Session::flush();
-				return Redirect::to('https://' . Request::server('SERVER_NAME') .Config::get("$this->cpath.port") . Config::get("$this->cpath.idp_logout"));
-            }
-        }
-		else
-		{
-            Session::flush();
-            return View::make(Config::get("$this->cpath.local_logout"));
-        }
-    }
-	
-	function getAttrStore() 
-	{
+				return Redirect::to(action($this->ctrpath . 'emulateLogout'));
+			} else {
+				Session::flush();
+				return Redirect::to('https://' . Request::server('SERVER_NAME') . Config::get("$this->cpath.port") . Config::get("$this->cpath.idp_logout"));
+			}
+		} else {
+			Session::flush();
+			return View::make(Config::get("$this->cpath.local_logout"));
+		}
+	}
+
+	function getAttrStore() {
 		return new \Shibalike\Attr\Store\ArrayStore(Config::get("$this->cpath.emulate_idp_users"));
 	}
 
@@ -233,53 +236,45 @@ class ShibbolethController extends Controller {
 			->build();
 		return new \Shibalike\StateManager\UserlandSession($session);
 	}
-	
-	public function emulateLogin()
-    {
-        $from = (Request::get('target') != null) ? Request::get('target') : $this->getServerVariable('HTTP_REFERER');
 
-        $this->sp->makeAuthRequest($from);
-        $this->sp->redirect();
-    }
+	public function emulateLogin() {
+		$from = (Request::get('target') != null) ? Request::get('target') : $this->getServerVariable('HTTP_REFERER');
 
-    public function emulateLogout()
-    {
-        $this->sp->logout();
-        die('Goodbye, fair user. <a href="' . $this->getServerVariable('HTTP_REFERER') . '">Return from whence you came</a>!');
-    }
+		$this->sp->makeAuthRequest($from);
+		$this->sp->redirect();
+	}
 
-    public function emulateIdp()
-    {
-		if (Request::get('username') != null)
-		{
-            $username = '';
-            if (Request::get('username') === Request::get('password')) 
-			{
-                $username = Request::get('username');
-            }
-            
-            $userAttrs = $this->idp->fetchAttrs($username);
-            if ($userAttrs) 
-			{
-                $this->idp->markAsAuthenticated($username);
-                $this->idp->redirect();
-            } 
-			else 
-			{
-                echo "Sorry. You failed to authenticate. <a href='idp'>Try again</a>";
-            }
-        }
+	public function emulateLogout() {
+		$this->sp->logout();
+		die('Goodbye, fair user. <a href="' . $this->getServerVariable('HTTP_REFERER') . '">Return from whence you came</a>!');
+	}
+
+	public function emulateIdp() {
+		if (Request::get('username') != null) {
+			$username = '';
+			if (Request::get('username') === Request::get('password')) {
+				$username = Request::get('username');
+			}
+
+			$userAttrs = $this->idp->fetchAttrs($username);
+			if ($userAttrs) {
+				$this->idp->markAsAuthenticated($username);
+				$this->idp->redirect();
+			} else {
+				echo "Sorry. You failed to authenticate. <a href='idp'>Try again</a>";
+			}
+		}
 		?>
-		<form action="" method="post">
-			<dl>
-				<dt>Username</dt><dd><input size="20" name="username"></dd>
-				<dt>Password</dt><dd><input size="20" name="password" type="password"></dd>
-			</dl>
-			<p><input type="submit" value="Login"></p>
-		</form>
-	<?php
-    }
-	
+			<form action="" method="post">
+				<dl>
+					<dt>Username</dt><dd><input size="20" name="username"></dd>
+					<dt>Password</dt><dd><input size="20" name="password" type="password"></dd>
+				</dl>
+				<p><input type="submit" value="Login"></p>
+			</form>
+		<?php
+}
+
 	/**
 	 * Wrapper function for getting server variables.
 	 * Since Shibalike injects $_SERVER variables Laravel
@@ -287,17 +282,26 @@ class ShibbolethController extends Controller {
 	 * using the emulated IdP or a real one, we use the
 	 * appropriate function.
 	 */
-	private function getServerVariable($variableName)
-	{
-		if (Config::get("$this->cpath.emulate_idp") == true)
-		{ 
+	private function getServerVariable($variableName) {
+		if (Config::get("$this->cpath.emulate_idp") == true) {
 			return isset($_SERVER[$variableName]) ? $_SERVER[$variableName] : null;
-		}
-		else
-		{
+		} else {
 			$nonRedirect = Request::server($variableName);
-            $redirect = Request::server('REDIRECT_' . $variableName);
-            return (!empty($nonRedirect)) ? $nonRedirect : $redirect;
+			$redirect    = Request::server('REDIRECT_' . $variableName);
+			return (!empty($nonRedirect)) ? $nonRedirect : $redirect;
+		}
+	}
+
+	/*
+	 * simple function that allows config variables to
+	 * be either names of Views OR redirect routes
+	 */
+	// TODO: use this for all "view" variables
+	private function viewOrRedirect($view) {
+		if (View::exists($view)) {
+			return View::make($view);
+		} else {
+			return Redirect::to($view);
 		}
 	}
 }

--- a/src/controllers/ShibbolethController.php
+++ b/src/controllers/ShibbolethController.php
@@ -165,7 +165,7 @@ class ShibbolethController extends Controller {
 		} else {
 			//Add user to group and send through auth.
 			if (isset($email)) {
-				if (Config::get("$this->cpath.add_new_users")) {
+				if (Config::get("$this->cpath.add_new_users", true)) {
 					$user = UserShibboleth::create(array(
 						'email'      => $email,
 						'type'       => 'shibboleth',


### PR DESCRIPTION
Introduces `add_new_users` config variable that determines whether or not idp users should be added to the application database. The default (historical) behavior is `true`. If set to `false`, users who pass idp but have no local entry will simply be marked with `'auth_type' => 'no_user'` and sent to the login failure view.

This was motivated by a desire to reduce clutter in the user table for a project where users must be pre-approved before use.